### PR TITLE
Resolve messages about the plugin slowing Homebridge

### DIFF
--- a/src/accessories/gridstatus.js
+++ b/src/accessories/gridstatus.js
@@ -6,7 +6,7 @@ var reset = require('../helper/event-value-resetter.js');
 
 var _httpGetRequest = require('../helper/my-http-request.js');
 var _checkRequestError = require('../helper/check-for-request-error.js');
-
+var _createFastGetter = require('../helper/fast-getter.js');
 
 var Characteristic, Service, FakeGatoHistoryService, FakeGatoHistorySetting;
 
@@ -53,7 +53,7 @@ Gridstatus.prototype = {
             this.gridIsUpSwitch = new Service.Switch(this.name + ' "Up"', '1');
             this.gridIsUpSwitch
                 .getCharacteristic(Characteristic.On)
-                .on('get', this.getGridIsUpSwitch.bind(this))
+                .on('get', _createFastGetter(this.getGridIsUpSwitch.bind(this), this.log))
                 .on('set', this.setGridIsUpSwitch.bind(this));
             eventPolling(this.gridIsUpSwitch, Characteristic.On, this.pollingInterval);
             services.push(this.gridIsUpSwitch);
@@ -63,7 +63,7 @@ Gridstatus.prototype = {
             this.gridIsDownSwitch = new Service.Switch(this.name + ' "Down"', '2');
             this.gridIsDownSwitch
                 .getCharacteristic(Characteristic.On)
-                .on('get', this.getGridIsDownSwitch.bind(this))
+                .on('get', _createFastGetter(this.getGridIsDownSwitch.bind(this), this.log))
                 .on('set', this.setGridIsDownSwitch.bind(this));
             eventPolling(this.gridIsDownSwitch, Characteristic.On, this.pollingInterval);
             services.push(this.gridIsDownSwitch);
@@ -73,7 +73,7 @@ Gridstatus.prototype = {
             this.gridIsNotYetInSyncSwitch = new Service.Switch(this.name + ' "Not Yet In Sync"', '3');
             this.gridIsNotYetInSyncSwitch
                 .getCharacteristic(Characteristic.On)
-                .on('get', this.getGridIsNotYetInSyncSwitch.bind(this))
+                .on('get', _createFastGetter(this.getGridIsNotYetInSyncSwitch.bind(this), this.log))
                 .on('set', this.setGridIsNotYetInSyncSwitch.bind(this));
             eventPolling(this.gridIsNotYetInSyncSwitch, Characteristic.On, this.pollingInterval);
             services.push(this.gridIsNotYetInSyncSwitch);
@@ -83,7 +83,7 @@ Gridstatus.prototype = {
             this.gridIsUpSensor = new Service.ContactSensor(this.name + ' "Up" Sensor', '4');
             this.gridIsUpSensor
                 .getCharacteristic(Characteristic.ContactSensorState)
-                .on('get', this.getGridIsUpSwitch.bind(this))
+                .on('get', _createFastGetter(this.getGridIsUpSwitch.bind(this), this.log))
             eventPolling(this.gridIsUpSensor, Characteristic.ContactSensorState, this.pollingInterval);
             services.push(this.gridIsUpSensor);
         }
@@ -92,7 +92,7 @@ Gridstatus.prototype = {
             this.gridIsDownSensor = new Service.ContactSensor(this.name + ' "Down" Sensor', '5');
             this.gridIsDownSensor
                 .getCharacteristic(Characteristic.ContactSensorState)
-                .on('get', this.getGridIsDownSwitch.bind(this))
+                .on('get', _createFastGetter(this.getGridIsDownSwitch.bind(this), this.log))
             eventPolling(this.gridIsDownSensor, Characteristic.ContactSensorState, this.pollingInterval);
             services.push(this.gridIsDownSensor);
         }

--- a/src/accessories/powermeter-line-graph.js
+++ b/src/accessories/powermeter-line-graph.js
@@ -2,6 +2,7 @@ var moment   = require('moment');
 
 var Polling = require('../helper/polling.js');
 var eventPolling = require('../helper/simple-event-polling.js');
+var _createFastGetter = require('../helper/fast-getter.js');
 
 var Characteristic, Service, FakeGatoHistoryService, FakeGatoHistorySetting;
 
@@ -49,7 +50,7 @@ PowerMeter.prototype = {
                 minValue: -10000,
                 maxValue: 10000
             })
-            .on('get', this.getWatt.bind(this));
+            .on('get', _createFastGetter(this.getWatt.bind(this), this.log));
         eventPolling(this.energyLG, Characteristic.CurrentTemperature, this.pollingInterval);
         services.push(this.energyLG);
 

--- a/src/accessories/powermeter.js
+++ b/src/accessories/powermeter.js
@@ -3,6 +3,7 @@ var moment   = require('moment');
 var Polling = require('../helper/polling.js');
 var eventPolling = require('../helper/simple-event-polling.js');
 var reset = require('../helper/event-value-resetter.js');
+var _createFastGetter = require('../helper/fast-getter.js');
 
 var Characteristic, Service, FakeGatoHistoryService, FakeGatoHistorySetting;
 
@@ -47,13 +48,13 @@ PowerMeter.prototype = {
             this.wattVisualizer = new Service.Fan(this.name + ' ' + 'Flow');
             this.wattVisualizer
                 .getCharacteristic(Characteristic.On)
-                .on('get', this.getOnWattVisualizer.bind(this))
+                .on('get', _createFastGetter(this.getOnWattVisualizer.bind(this), this.log))
                 .on('set', this.setOnWattVisualizer.bind(this));
             eventPolling(this.wattVisualizer, Characteristic.On, this.pollingInterval);
             this.wattVisualizer
                 .getCharacteristic(Characteristic.RotationSpeed)
                 .setProps({maxValue: 100000, minValue: -100000, minStep: 1, unit: 'Watts'})
-                .on('get', this.getRotSpWattVisualizer.bind(this))
+                .on('get', _createFastGetter(this.getRotSpWattVisualizer.bind(this), this.log))
                 .on('set', this.setRotSpWattVisualizer.bind(this));
             eventPolling(this.wattVisualizer, Characteristic.RotationSpeed, this.pollingInterval);
             services.push(this.wattVisualizer);
@@ -67,7 +68,7 @@ PowerMeter.prototype = {
                 'Power Meter');
             this.powerConsumption
                 .getCharacteristic(Characteristic.CurrentPowerConsumption)
-                .on('get', this.getWatt.bind(this));
+                .on('get', _createFastGetter(this.getWatt.bind(this), this.log));
             eventPolling(this.powerConsumption, Characteristic.CurrentPowerConsumption, this.pollingInterval);
             services.push(this.powerConsumption);
         }
@@ -79,7 +80,7 @@ PowerMeter.prototype = {
             this.powerConsumption
                 .getCharacteristic(Characteristic.ResetTotal)
                 .on('set', this.setResetTotalConsumption.bind(this))
-                .on('get', this.getResetTotalConsumption.bind(this));
+                .on('get', _createFastGetter(this.getResetTotalConsumption.bind(this), this.log));
 
             this.powerMeterHistory = 
                 new FakeGatoHistoryService('energy', this, FakeGatoHistorySetting);

--- a/src/accessories/powerwall.js
+++ b/src/accessories/powerwall.js
@@ -6,6 +6,7 @@ var reset = require('../helper/event-value-resetter.js');
 
 var _httpGetRequest = require('../helper/my-http-request.js');
 var _checkRequestError = require('../helper/check-for-request-error.js');
+var _createFastGetter = require('../helper/fast-getter.js');
 
 
 var Characteristic, Service, FakeGatoHistoryService, FakeGatoHistorySetting;
@@ -59,7 +60,7 @@ Powerwall.prototype = {
         this.stateSwitch = new Service.Switch(this.name, "1");
         this.stateSwitch
             .getCharacteristic(Characteristic.On)
-            .on('get', this.getStateSwitch.bind(this))
+            .on('get', _createFastGetter(this.getStateSwitch.bind(this), this.log))
             .on('set', this.setStateSwitch.bind(this));
         eventPolling(this.stateSwitch, Characteristic.On, this.pollingInterval);
         services.push(this.stateSwitch);
@@ -68,15 +69,15 @@ Powerwall.prototype = {
             new Service.BatteryService(this.name + ' ' + 'Battery');
         this.battery
             .getCharacteristic(Characteristic.BatteryLevel)
-            .on('get', this.getBatteryLevel.bind(this));
+            .on('get', _createFastGetter(this.getBatteryLevel.bind(this), this.log));
         eventPolling(this.battery, Characteristic.BatteryLevel, this.pollingInterval);
         this.battery
             .getCharacteristic(Characteristic.ChargingState)
-            .on('get', this.getChargingState.bind(this));
+            .on('get', _createFastGetter(this.getChargingState.bind(this), this.log));
         eventPolling(this.battery, Characteristic.ChargingState, this.pollingInterval);
         this.battery
             .getCharacteristic(Characteristic.StatusLowBattery)
-            .on('get', this.getLowBattery.bind(this));
+            .on('get', _createFastGetter(this.getLowBattery.bind(this), this.log));
         eventPolling(this.battery, Characteristic.StatusLowBattery, this.pollingInterval);
         services.push(this.battery);
 
@@ -85,22 +86,22 @@ Powerwall.prototype = {
                 new Service.Lightbulb(this.name + ' ' + 'Charge');
             this.batteryVisualizer
                 .getCharacteristic(Characteristic.On)
-                .on('get', this.getOnBatteryVisualizer.bind(this))
+                .on('get', _createFastGetter(this.getOnBatteryVisualizer.bind(this), this.log))
                 .on('set', this.setOnBatteryVisualizer.bind(this));
             eventPolling(this.batteryVisualizer, Characteristic.On, this.pollingInterval);
             this.batteryVisualizer
                 .getCharacteristic(Characteristic.Hue)
-                .on('get', this.getHueBatteryVisualizer.bind(this))
+                .on('get', _createFastGetter(this.getHueBatteryVisualizer.bind(this), this.log))
                 .on('set', this.setHueBatteryVisualizer.bind(this));
             eventPolling(this.batteryVisualizer, Characteristic.Hue, this.pollingInterval);
             this.batteryVisualizer
                 .getCharacteristic(Characteristic.Brightness)
-                .on('get', this.getBatteryLevel.bind(this))
+                .on('get', _createFastGetter(this.getBatteryLevel.bind(this), this.log))
                 .on('set', this.setBrightnessBatteryVisualizer.bind(this));
             eventPolling(this.batteryVisualizer, Characteristic.Brightness, this.pollingInterval);
             this.batteryVisualizer // Set saturation to fix compatibility with Homebridge Alexa
                 .getCharacteristic(Characteristic.Saturation)
-                .on('get', this.getConstantSaturationBatteryVisualizer.bind(this))
+                .on('get', _createFastGetter(this.getConstantSaturationBatteryVisualizer.bind(this), this.log))
                 .on('set', this.setSaturationBatteryVisualizer.bind(this));
             services.push(this.batteryVisualizer);
         }
@@ -116,7 +117,7 @@ Powerwall.prototype = {
                     minValue: 0,
                     maxValue: 100
                 })
-                .on('get', this.getBatteryLevel.bind(this));
+                .on('get', _createFastGetter(this.getBatteryLevel.bind(this), this.log));
             eventPolling(this.batteryCharge, Characteristic.CurrentTemperature, this.pollingInterval);
             services.push(this.batteryCharge);
 
@@ -136,7 +137,7 @@ Powerwall.prototype = {
             this.batteryIsLowSwitch = new Service.Switch(this.name + ' State: "Battery Is Low"', '2');
             this.batteryIsLowSwitch
                 .getCharacteristic(Characteristic.On)
-                .on('get', this.getLowBattery.bind(this))
+                .on('get', _createFastGetter(this.getLowBattery.bind(this), this.log))
                 .on('set', this.setBatteryIsLowSwitch.bind(this));
             eventPolling(this.batteryIsLowSwitch, Characteristic.On, this.pollingInterval);
             services.push(this.batteryIsLowSwitch);
@@ -146,7 +147,7 @@ Powerwall.prototype = {
             this.batteryIsChargingSwitch = new Service.Switch(this.name + ' State: "Battery Is Charging"', '3');
             this.batteryIsChargingSwitch
                 .getCharacteristic(Characteristic.On)
-                .on('get', this.getChargingState.bind(this))
+                .on('get', _createFastGetter(this.getChargingState.bind(this), this.log))
                 .on('set', this.setBatteryIsChargingSwitch.bind(this));
             eventPolling(this.batteryIsChargingSwitch, Characteristic.On, this.pollingInterval);
             services.push(this.batteryIsChargingSwitch);

--- a/src/helper/fast-getter.js
+++ b/src/helper/fast-getter.js
@@ -1,0 +1,44 @@
+/**
+ * Returns a wrapper function that can be added directly to a characteristic that
+ * will ensure that the plugin responds quickly to get requests.
+ * @param {function} actualGetter 
+ * @param {} log 
+ * @returns 
+ */
+module.exports = function createFastGetter(actualGetter, log) {
+    let lastValue = null;
+
+    return function(callback) {
+        const characteristic = this;
+
+        let timeoutResponded = false;
+
+        /* Respond with a cached value if the actual getter doesn't respond quickly */
+        const timeout = setTimeout(function() {
+            timeoutResponded = true;
+            if (lastValue) {
+                log.debug(`${characteristic.displayName}: timeout returning last result: ${lastValue.error} ${lastValue.result}`);
+                callback(lastValue.error, lastValue.result);
+            } else {
+                log.debug(`${characteristic.displayName}: timeout returning no result`);
+                callback(new Error('Device slow to respond'), null);
+            }
+        }, 500);
+
+        actualGetter(function(error, result) {
+            lastValue = { error, result };
+
+            if (!timeoutResponded) {
+                clearTimeout(timeout);
+                log.debug(`${characteristic.displayName}: returning actual result ${error} ${result}`);
+                callback(error, result);
+            } else if (error) {
+                log.debug(`${characteristic.displayName}: updating characteristic with error for late result: ${error}`);
+                characteristic.updateValue(error);
+            } else {
+                log.debug(`${characteristic.displayName}: updating characteristic with late result: ${result}`);
+                characteristic.updateValue(result);
+            }
+        })
+    }
+};


### PR DESCRIPTION
It seems that sometimes the Powerwall is slow to respond, so I've built a wrapper around the getters that will return with a cached value if the Powerwall doesn't respond quickly. This resolves the issue described https://github.com/homebridge/homebridge/wiki/Characteristic-Warnings#this-plugin-slows-down-homebridge